### PR TITLE
Add supermodeltools.com/trial CTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,6 +637,8 @@ mcp_server:
 
 **Supermodel Codebase Analysis Server:**
 
+Get an API key by starting a free trial at [supermodeltools.com/trial](https://supermodeltools.com/trial).
+
 ```yaml
 mcp_server:
   command: "npx"

--- a/README.md
+++ b/README.md
@@ -637,7 +637,7 @@ mcp_server:
 
 **Supermodel Codebase Analysis Server:**
 
-Get an API key by starting a free trial at [supermodeltools.com/trial](https://supermodeltools.com/trial).
+**Save 40%+ on agent token costs — start free → [supermodeltools.com/trial](https://supermodeltools.com/trial)**
 
 ```yaml
 mcp_server:


### PR DESCRIPTION
Adds the new `/trial` signup page link to the README so readers have a one-click path to start a free trial and get an API key.

Part of a coordinated set of PRs across the supermodeltools org adding `/trial` to each product's main user-facing surface.

Verified: https://supermodeltools.com/trial returns 200 (Pro $19/mo, Growth $199/mo, 14-day trial via Stripe).

Draft for review.